### PR TITLE
Fix/show profile

### DIFF
--- a/api/apps.ts
+++ b/api/apps.ts
@@ -2,22 +2,11 @@ import { neon } from '@neondatabase/serverless';
 import { drizzle } from 'drizzle-orm/neon-http';
 import { apps, featuredApps, bumpRules } from '../src/db/schema';
 import { eq, desc, and, gte, lte } from 'drizzle-orm';
+import { normalizeOpalLogo } from '../src/lib/branding';
 
 export const config = {
   runtime: 'edge',
 };
-
-const OPAL_CANONICAL_LOGO = '/icons/opal2.png';
-
-function normalizeOpalLogo<T extends { slug: string | null; logoUrl: string | null }>(app: T): T {
-  if (app.slug === 'opal') {
-    return {
-      ...app,
-      logoUrl: OPAL_CANONICAL_LOGO,
-    };
-  }
-  return app;
-}
 
 export default async function handler(_request: Request) {
   try {

--- a/api/profile/[slug].ts
+++ b/api/profile/[slug].ts
@@ -2,12 +2,11 @@ import { neon } from '@neondatabase/serverless';
 import { drizzle } from 'drizzle-orm/neon-http';
 import { users, userProfileApps, apps, appSubmissions } from '../../src/db/schema';
 import { eq, and } from 'drizzle-orm';
+import { OPAL_CANONICAL_LOGO } from '../../src/lib/branding';
 
 export const config = {
   runtime: 'edge',
 };
-
-const OPAL_CANONICAL_LOGO = '/icons/opal2.png';
 
 const connectionString = process.env.DATABASE_URL;
 if (!connectionString) {

--- a/api/profile/manage.ts
+++ b/api/profile/manage.ts
@@ -2,22 +2,11 @@ import { neon } from '@neondatabase/serverless';
 import { drizzle } from 'drizzle-orm/neon-http';
 import { users, userProfileApps, apps, appSubmissions, userPreferences } from '../../src/db/schema';
 import { eq, and, inArray } from 'drizzle-orm';
+import { normalizeOpalLogo } from '../../src/lib/branding';
 
 export const config = {
   runtime: 'edge',
 };
-
-const OPAL_CANONICAL_LOGO = '/icons/opal2.png';
-
-function normalizeOpalLogo<T extends { slug: string | null; logoUrl: string | null }>(app: T): T {
-  if (app.slug === 'opal') {
-    return {
-      ...app,
-      logoUrl: OPAL_CANONICAL_LOGO,
-    };
-  }
-  return app;
-}
 
 const connectionString = process.env.DATABASE_URL;
 if (!connectionString) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@neondatabase/serverless": "^1.0.2",
         "@types/qrcode": "^1.5.6",
         "cheerio": "^1.2.0",
+        "concurrently": "^9.2.1",
         "cors": "^2.8.6",
         "dotenv": "^17.2.3",
         "drizzle-orm": "^0.45.1",
@@ -33,7 +34,6 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.2",
         "autoprefixer": "^10.4.24",
-        "concurrently": "^9.2.1",
         "drizzle-kit": "^0.31.8",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.18",
@@ -85,7 +85,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2956,7 +2955,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.1.0.tgz",
       "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2998,7 +2996,6 @@
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4868,7 +4865,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5235,7 +5231,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5340,7 +5335,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -5357,7 +5351,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -5445,7 +5438,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -5505,7 +5497,6 @@
       "version": "9.2.1",
       "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
       "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
@@ -6634,7 +6625,6 @@
       "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -6687,7 +6677,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7283,7 +7272,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8615,7 +8603,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8890,7 +8877,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8900,7 +8886,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9090,7 +9075,6 @@
       "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9183,7 +9167,6 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -9380,7 +9363,6 @@
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
       "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9620,7 +9602,6 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -9775,7 +9756,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
@@ -9847,7 +9827,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {
@@ -9922,7 +9901,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10576,7 +10554,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -10717,7 +10694,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -10776,7 +10752,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -10793,7 +10768,6 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -10812,7 +10786,6 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"

--- a/src/components/PersonalProfile.tsx
+++ b/src/components/PersonalProfile.tsx
@@ -122,15 +122,15 @@ export function PersonalProfile({ slug }: { slug: string }) {
   };
 
   const handleAddExistingApp = async (appId: string): Promise<boolean> => {
-    const alreadyPinned = preferences.pinnedApps?.includes(appId);
-    if (!alreadyPinned) {
-      togglePinnedApp(appId);
-    }
-
     const added = await addAppToProfile(appId);
     if (!added) {
       addToast('Failed to add app to profile', 'error');
       return false;
+    }
+
+    const alreadyPinned = preferences.pinnedApps?.includes(appId);
+    if (!alreadyPinned) {
+      togglePinnedApp(appId);
     }
 
     addToast('App added to profile', 'success');

--- a/src/lib/branding.ts
+++ b/src/lib/branding.ts
@@ -1,0 +1,11 @@
+export const OPAL_CANONICAL_LOGO = '/icons/opal2.png';
+
+export function normalizeOpalLogo<T extends { slug: string | null; logoUrl: string | null }>(app: T): T {
+  if (app.slug === 'opal') {
+    return {
+      ...app,
+      logoUrl: OPAL_CANONICAL_LOGO,
+    };
+  }
+  return app;
+}

--- a/src/lib/branding.ts
+++ b/src/lib/branding.ts
@@ -1,6 +1,6 @@
 export const OPAL_CANONICAL_LOGO = '/icons/opal2.png';
 
-export function normalizeOpalLogo<T extends { slug: string | null; logoUrl: string | null }>(app: T): T {
+export function normalizeOpalLogo<T extends { slug: string | null; logoUrl: string | null }>(app: T): Omit<T, 'logoUrl'> & { logoUrl: string | null } {
   if (app.slug === 'opal') {
     return {
       ...app,


### PR DESCRIPTION
This pull request refactors how the canonical Opal logo and normalization logic are managed across the codebase. The main improvement is centralizing the `OPAL_CANONICAL_LOGO` constant and the `normalizeOpalLogo` function in a new branding utility, reducing duplication and improving maintainability. Additionally, there is a minor fix in the app pinning logic in the `PersonalProfile` component.

**Branding logic centralization:**

* Moved the `OPAL_CANONICAL_LOGO` constant and the `normalizeOpalLogo` function to a new file, `src/lib/branding.ts`, to serve as a single source of truth for branding-related utilities.
* Updated imports in `api/apps.ts` and `api/profile/manage.ts` to use `normalizeOpalLogo` from the new branding utility, and removed their local definitions. [[1]](diffhunk://#diff-594fe21ab87df6016258a4e9454057e715b8e9aaa17604c5c7f3cd552e94f9aaR5-L21) [[2]](diffhunk://#diff-099c346ca13e9372316b322f1fd86e183a43b606f7d1d649e154234165e8154aR5-L21)
* Updated import in `api/profile/[slug].ts` to use `OPAL_CANONICAL_LOGO` from the branding utility, removing the local constant. ([api/profile/[slug].tsR5-L11](diffhunk://#diff-a7d2b821176ede9e812b6cf30491dc732370b31cb283f3cf5b3e7f8e14caf31fR5-L11))

**Bug fix in component logic:**

* Fixed the order of operations in the `handleAddExistingApp` function in `PersonalProfile.tsx` so that pinning logic only runs after a successful app addition.